### PR TITLE
Eliminate some branches and improve blending documentation

### DIFF
--- a/assets/minecraft/shaders/program/transparency.fsh
+++ b/assets/minecraft/shaders/program/transparency.fsh
@@ -71,8 +71,7 @@ void main() {
     
     // Blend and merge the framebuffer samples
 
-    // We can disregard the first sample's alpha value: if it is translucent, 
-    // we know it will be overridden by an opaque pixel from the diffuse layer
+    // We don't need to consider the first layer's alpha value because the color components are already premultiplied
     vec3 tex = color_samples[0].rgb;
     for (int i = 1; i < sample_count; i++) {
         tex = blend(tex, color_samples[i]);

--- a/assets/minecraft/shaders/program/transparency.fsh
+++ b/assets/minecraft/shaders/program/transparency.fsh
@@ -45,10 +45,6 @@ varying vec2 texCoord;
 vec4 color_samples[NUM_LAYERS];
 float depth_samples[NUM_LAYERS];
 
-vec3 blend(vec3 tex, vec4 sample) {
-    return mix(tex, sample.rgb, sample.a);
-}
-
 void main() {
     // There will always be at least one sample (from the diffuse layer)
     int sample_count = 1;
@@ -68,9 +64,13 @@ void main() {
     try_insert_sample(CloudsSampler, CloudsDepthSampler);
     
     // Blend and merge the framebuffer samples
+
+    // We can disregard the first sample's alpha value: if it is translucent, 
+    // we know it will be overridden by an opaque pixel from the diffuse layer
     vec3 tex = color_samples[0].rgb;
     for (int i = 1; i < sample_count; i++) {
-        tex = blend(tex, color_samples[i]);
+        vec4 sample = color_samples[i];
+        tex = mix(tex, sample.rgb, sample.a);
     }
     
     // Write the blended colors to the final framebuffer output

--- a/assets/minecraft/shaders/program/transparency.fsh
+++ b/assets/minecraft/shaders/program/transparency.fsh
@@ -45,6 +45,11 @@ varying vec2 texCoord;
 vec4 color_samples[NUM_LAYERS];
 float depth_samples[NUM_LAYERS];
 
+vec3 blend(vec3 tex, vec4 sample) {
+    float factor = 1.0 - sample.a;
+    return (tex * factor) + sample.rgb;
+}
+
 void main() {
     // There will always be at least one sample (from the diffuse layer)
     int sample_count = 1;
@@ -69,8 +74,7 @@ void main() {
     // we know it will be overridden by an opaque pixel from the diffuse layer
     vec3 tex = color_samples[0].rgb;
     for (int i = 1; i < sample_count; i++) {
-        vec4 sample = color_samples[i];
-        tex = mix(tex, sample.rgb, sample.a);
+        tex = blend(tex, color_samples[i]);
     }
     
     // Write the blended colors to the final framebuffer output

--- a/assets/minecraft/shaders/program/transparency.fsh
+++ b/assets/minecraft/shaders/program/transparency.fsh
@@ -45,6 +45,7 @@ varying vec2 texCoord;
 vec4 color_samples[NUM_LAYERS];
 float depth_samples[NUM_LAYERS];
 
+// This blending works with color components that have already been premultiplied by their alpha component
 vec3 blend(vec3 tex, vec4 sample) {
     float factor = 1.0 - sample.a;
     return (tex * factor) + sample.rgb;

--- a/assets/minecraft/shaders/program/transparency.fsh
+++ b/assets/minecraft/shaders/program/transparency.fsh
@@ -25,7 +25,8 @@ varying vec2 texCoord;
         depth_samples[i] = texture2D(depth_sampler, texCoord).r; \
         \
         /* Perform an insertion sort at the given index in the array, sorted by descending depth */ \
-        while (depth_samples[i] > depth_samples[i - 1]) { \
+        /* Although the i>0 check will always be false on the first iteration, keeping it here seems to elide a branch */ \
+        while (i > 0 && depth_samples[i] > depth_samples[i - 1]) { \
             vec4 color = color_samples[i]; \
             color_samples[i] = color_samples[i - 1]; \
             color_samples[i - 1] = color; \
@@ -34,8 +35,7 @@ varying vec2 texCoord;
             depth_samples[i] = depth_samples[i - 1]; \
             depth_samples[i - 1] = depth; \
             \
-            /* Postpone the bounds check as it will never be true on the first iteration */ \
-            if (--i <= 0) break; \
+            i--; \
         } \
     } \
 }

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -2,6 +2,6 @@
 {
    "pack": {
       "pack_format": 5,
-      "description": "Shader optimizations for MC-186075 (mc20w22a, v1.1.1)"
+      "description": "Shader optimizations for MC-186075 (mc20w22a, v1.1.2)"
    }
 }


### PR DESCRIPTION
Observed a fairly consistent ~5FPS increase on my machine. As far as I can tell, the change to the blending loop should eliminate one branch (and blending op) for every fragment.

Previously, it would in theory always check that `0<sample_count` (which is always true)